### PR TITLE
コンテナ内のディレクトリ構成変更

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,15 +1,15 @@
 FROM python:3.10-buster
 ENV PATH=/app/.venv/bin:$PATH
 
-WORKDIR /app
+WORKDIR /app/fastapi
 
 RUN pip install poetry
 
-COPY ./app/poetry.lock /app
-COPY ./app/pyproject.toml /app
+COPY ./app/poetry.lock ./
+COPY ./app/pyproject.toml ./
 
 RUN poetry install --no-root
 
-COPY ./app/src /app
+WORKDIR /app/fastapi/src
 
 CMD ["poetry", "run", "uvicorn", "app:app", "--reload", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,11 @@ version: "3"
 services:
   mysql:
     image: mysql:8.0
+    container_name: "mysql"
     platform: linux/amd64
     build:
       context: .
       dockerfile: ./mysql/Dockerfile
-    container_name: "mysql"
     ports:
       - "3306:3306"
     environment:
@@ -25,21 +25,21 @@ services:
     build: 
       context: .
       dockerfile: ./app/Dockerfile
-        #volumes:
-        #  - ./app/src:/file #localで永続化する場合はこっち使う
+    volumes:
+      - ./app/src:/app/fastapi/src
     ports:
       - 8000:8000
     environment:
       TZ: Asia/Tokyo
 
   react:
+    container_name: "front"
     build:
       context: .
       dockerfile: ./front/Dockerfile
-    container_name: "front"
     volumes:
-      - ./front/src:/app/src
-      - ./front/public:/app/public
+      - ./front/src:/app/front/src
+      - ./front/public:/app/front/public
     ports:
       - 3000:3000
     tty: true

--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:19.4.0-buster
 
-WORKDIR /app
+WORKDIR /app/front
 
 COPY ./front/package.json ./
 COPY ./front/package-lock.json ./


### PR DESCRIPTION
コンテナ内のディレクトリ構成を変更
fastapi, reactそれぞれのディレクトリを作成して、その中にソースコードを入れられるようにしました。
動作検証済み

ちなみに、fastapiはsrc/以下　reactはpublic/ と src/以下に置いたファイルはコンテナ内と同期しているので、自動的にコピーされます。